### PR TITLE
do not retry sign() requests

### DIFF
--- a/src/utils/evmTransactions.js
+++ b/src/utils/evmTransactions.js
@@ -51,7 +51,7 @@ const createSignRequestAndWaitSignature = async ({
     ...signArgs[1],
     retry: {
       delay: 10000,
-      retryCount: 12,
+      retryCount: 0,
     },
     transaction: transactionArgs,
   });


### PR DESCRIPTION
This service is intended to make signature requests and represent system uptime, it should never retry to return representative data back.